### PR TITLE
fix(aks)!:remove append aks name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@
 */
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                            = format("aks-%s", var.name)
+  name                            = var.name
   location                        = var.location
   resource_group_name             = var.resource_group_name
   dns_prefix                      = replace(var.name, "-", "")


### PR DESCRIPTION
Removing that the AKS name appended at the beginning of the cluster name