### PR TITLE
feat: add support for defender and azure monitor enabling

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -314,3 +314,43 @@ variable "sku_tier" {
     error_message = "Value must be either Free or Standard"
   }
 }
+
+variable "default_log_analytics_workspace_id" {
+  description = <<EOF
+  (Optional) The id of the Log Analytics Workspace to use as default for Defender and Azure Monitor.
+  Each of these services can be configured to use a different Log Analytics Workspace, which will override this setting.
+  If neither this nor the service spesific variable is specified, and the services are enabled, a new Log Analytics Workspace will be created.
+  EOF
+  type        = string
+  default     = null
+}
+
+variable "microsoft_defender" {
+  description = <<EOF
+  (Optional) Enable or disable Microsoft Defender (Security profile) for the cluster. Defaults to false.
+  If neither microsoft_defender.log_analytics_workspace_id nor default_log_analytics_workspace_id is specified, a new Log Analytics Workspace will be created with the same name as the AKS cluster and in the same resource group.
+  EOF
+  type = object({
+    enabled                    = optional(bool, false)
+    log_analytics_workspace_id = optional(string, null)
+  })
+  default = {
+    enabled                    = false
+    log_analytics_workspace_id = null
+  }
+}
+
+variable "azure_monitor" {
+  description = <<EOF
+  (Optional) Enable or disable Azure Monitor for the cluster. Defaults to false.
+  If neither azure_monitor.log_analytics_workspace_id nor default_log_analytics_workspace_id is specified, a new Log Analytics Workspace will be created with the same name as the AKS cluster and in the same resource group.
+  EOF
+  type = object({
+    enabled                    = optional(bool, false)
+    log_analytics_workspace_id = optional(string, null)
+  })
+  default = {
+    enabled                    = false
+    log_analytics_workspace_id = null
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -342,15 +342,15 @@ variable "microsoft_defender" {
 
 variable "azure_monitor" {
   description = <<EOF
-  (Optional) Enable or disable Azure Monitor for the cluster. Defaults to false.
+  (Optional) Enable or disable Azure Monitor for the cluster. Defaults to true.
   If neither azure_monitor.log_analytics_workspace_id nor default_log_analytics_workspace_id is specified, a new Log Analytics Workspace will be created with the same name as the AKS cluster and in the same resource group.
   EOF
   type = object({
-    enabled                    = optional(bool, false)
+    enabled                    = optional(bool, true)
     log_analytics_workspace_id = optional(string, null)
   })
   default = {
-    enabled                    = false
+    enabled                    = true
     log_analytics_workspace_id = null
   }
 }


### PR DESCRIPTION
Adds support for enabling Microsoft Defender and Azure Monitor.
Gives the possibility to set a default log analytics workspace id to use across these services, and if needed can also be specified at service level. Service level variable will override the default variable.

Microsoft Defender defaults to false, Azure Monitor defaults to true.

If Defender or AMA is enabled, but no variable is set for the workspace id, a log analytics workspace will be created with the default sku of "PerGB2018" and 30 days retention.

Closes #11 #16 #34 